### PR TITLE
Updated stack.hpp

### DIFF
--- a/src/stack.hpp
+++ b/src/stack.hpp
@@ -1,14 +1,16 @@
-#include <cassert>
+#include <stdexcept>
 #include <cstdint>
 
 template <typename T, const int32_t capacity>
 class Stack
 {
 public:
-    const bool  empty ();
-    const T&    peek  ();
-    const T&    pop   ();
-    void        push  (const T& element);
+    const bool  empty () noexcept const;
+    const T&    peek  () const;
+    const T&    pop   () noexcept;
+    
+    template<typename U>
+    void        push  (U&& element);
 
 private:
     int32_t     top            =  -1;
@@ -17,31 +19,41 @@ private:
 
 
 template<typename T, const int32_t capacity>
-const bool      Stack<T, capacity>::empty()
+const bool      Stack<T, capacity>::empty() noexcept const
 {
     return top == -1;
 }
 
 template<typename T, const int32_t capacity>
-const T&        Stack<T, capacity>::peek()
+const T&        Stack<T, capacity>::peek() const
 {
-    assert(!empty());
-
+    if(empty())
+        throw std::runtime_error("stack is empty");
+    
     return data[top];
 }
 
 template<typename T, const int32_t capacity>
-const T&        Stack<T, capacity>::pop()
+const T&        Stack<T, capacity>::pop() noexcept
 {
-    auto& data = peek();
+    if(empty())
+        throw std::runtime_error("stack is empty");
+    
+    auto elem = data[top];
+    
+    data[top]->~T();
     top--;
 
-    return data;
+    return elem;
 }
 
 template<typename T, const int32_t capacity>
-void            Stack<T, capacity>::push(const T &element)
+template<typename U>
+void            Stack<T, capacity>::push(U&& element)
 {
+    static_assert(std::is_same<std::decay<T>,
+                  std::decay<U>>::value, "argument type or qualifier doesn't match")
     top++;
-    data[top] = element;
+    data[top] = T();
+    data[top] = std::forward<U>(element);
 }


### PR DESCRIPTION
Few improvements are required.
The current change requires T to be default constructible.
Making an explicit move constructor would allow non default-constructible push.
(I guess?)